### PR TITLE
解决自定义控件锚点位置没有相对地图的问题

### DIFF
--- a/src/controls/Control.vue
+++ b/src/controls/Control.vue
@@ -27,7 +27,7 @@ export default {
         this.defaultOffset = createSize(BMap, offset)
       }
       Control.prototype = new BMap.Control()
-      Control.prototype.initialize = map => map.getContainer().appendChild($el), $el
+      Control.prototype.initialize = map => map.getContainer().appendChild($el)
       this.originInstance = new Control(anchor, offset)
       map.addControl(this.originInstance)
     }

--- a/src/controls/Control.vue
+++ b/src/controls/Control.vue
@@ -27,7 +27,7 @@ export default {
         this.defaultOffset = createSize(BMap, offset)
       }
       Control.prototype = new BMap.Control()
-      Control.prototype.initialize = map => $el
+      Control.prototype.initialize = map => map.getContainer().appendChild($el), $el
       this.originInstance = new Control(anchor, offset)
       map.addControl(this.originInstance)
     }


### PR DESCRIPTION

![4](https://user-images.githubusercontent.com/24430116/34906319-3faf5d58-f8a6-11e7-8069-9f90335690a3.png)

Control.vue中这样修改解决问题。

-      Control.prototype.initialize = map => $el
+      Control.prototype.initialize = map => map.getContainer().appendChild($el), $el