### PR TITLE
解决icon更改后，角度状态不会保持的问题

### DIFF
--- a/src/overlays/Marker.vue
+++ b/src/overlays/Marker.vue
@@ -88,9 +88,9 @@ export default {
     icon: {
       deep: true,
       handler (val) {
-        const {BMap, originInstance} = this
+        const {BMap, originInstance, rotation} = this
         originInstance && originInstance.setIcon(createIcon(BMap, val))
-        this.rotation && originInstance && originInstance.setRotation(this.rotation)
+        rotation && originInstance && originInstance.setRotation(rotation)
       }
     },
     massClear (val) {

--- a/src/overlays/Marker.vue
+++ b/src/overlays/Marker.vue
@@ -90,7 +90,7 @@ export default {
       handler (val) {
         const {BMap, originInstance} = this
         originInstance && originInstance.setIcon(createIcon(BMap, val))
-        originInstance && originInstance.setRotation(this.rotation)
+        this.rotation && originInstance && originInstance.setRotation(this.rotation)
       }
     },
     massClear (val) {

--- a/src/overlays/Marker.vue
+++ b/src/overlays/Marker.vue
@@ -90,6 +90,7 @@ export default {
       handler (val) {
         const {BMap, originInstance} = this
         originInstance && originInstance.setIcon(createIcon(BMap, val))
+        originInstance && originInstance.setRotation(this.rotation)
       }
     },
     massClear (val) {


### PR DESCRIPTION
如果之前设置了marker的rotation，而且后面更改了marker的icon，造成marker的rotation会被重置。
所以在icon的watcher里面同步修改一下rotation就能解决这个问题