### PR TITLE
Update .npmignore 排除.babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 dist
 docs
 coverage
+.babelrc


### PR DESCRIPTION
hi. 局部注册使用时。 babel 会去读 */node_modules/vue-baidu-map/.babelrc 下的文件 导致 需要安装你babel 中的依赖包。 这不是一个特别好的方式。希望npm 发布的时候可以排除掉 babelrc