### PR TITLE
[overlay] Use correct strokeWeight fn for overlay components

### DIFF
--- a/components/extra/CurveLine.vue
+++ b/components/extra/CurveLine.vue
@@ -64,7 +64,7 @@ export default {
       this.originInstance.setStrokeOpacity(val)
     },
     strokeWeight (val) {
-      this.originInstance.setStrokeOpacity(val)
+      this.originInstance.setStrokeWeight(val)
     },
     strokeStyle (val) {
       this.originInstance.setStrokeStyle(val)

--- a/components/overlays/Circle.vue
+++ b/components/overlays/Circle.vue
@@ -81,7 +81,7 @@ export default {
       this.originInstance.setStrokeOpacity(val)
     },
     strokeWeight (val) {
-      this.originInstance.setStrokeOpacity(val)
+      this.originInstance.setStrokeWeight(val)
     },
     strokeStyle (val) {
       this.originInstance.setStrokeStyle(val)

--- a/components/overlays/Polygon.vue
+++ b/components/overlays/Polygon.vue
@@ -59,7 +59,7 @@ export default {
       this.originInstance.setStrokeOpacity(val)
     },
     strokeWeight (val) {
-      this.originInstance.setStrokeOpacity(val)
+      this.originInstance.setStrokeWeight(val)
     },
     strokeStyle (val) {
       this.originInstance.setStrokeStyle(val)

--- a/components/overlays/Polyline.vue
+++ b/components/overlays/Polyline.vue
@@ -50,7 +50,7 @@ export default {
       this.originInstance.setStrokeOpacity(val)
     },
     strokeWeight (val) {
-      this.originInstance.setStrokeOpacity(val)
+      this.originInstance.setStrokeWeight(val)
     },
     strokeStyle (val) {
       this.originInstance.setStrokeStyle(val)


### PR DESCRIPTION
`strokeWeight` is calling the incorrect setter function (`setStrokeOpacity`), causing the opacity to change when using `:stroke-weight` on following components:
- CurveLine
- Circle
- Polygon
- Polyline

Changing the methods called on `this.originInstance` in each component fixes this behaviour.
