### PR TITLE
覆盖物体对象更新

### DIFF
--- a/components/base/events.js
+++ b/components/base/events.js
@@ -65,7 +65,8 @@ export default {
     'mouseout',
     'mouseover',
     'remove',
-    'lineupdate'
+    'lineupdate',
+    'rightclick'
   ],
   'bm-polygon': [
     'click',
@@ -75,7 +76,8 @@ export default {
     'mouseout',
     'mouseover',
     'remove',
-    'lineupdate'
+    'lineupdate',
+    'rightclick'
   ],
   'bm-circle': [
     'click',
@@ -85,7 +87,8 @@ export default {
     'mouseout',
     'mouseover',
     'remove',
-    'lineupdate'
+    'lineupdate',
+    'rightclick'
   ],
   'bm-label': [
     'click',

--- a/components/others/Boundary.vue
+++ b/components/others/Boundary.vue
@@ -1,7 +1,6 @@
 <template>
   <div v-if="paths.length">
     <bm-polygon
-      isBoundary
       v-for="(path, index) of paths"
       :key="index"
       :path="path"
@@ -13,6 +12,7 @@
       :fill-color="fillColor"
       :mass-clear="massClear"
       :clicking="clicking"
+      overLayoutKey="boundary"
       @click="$emit('click', $event)"
       @dblclick="$emit('dblclick', $event)"
       @mousedown="$emit('mousedown', $event)"

--- a/components/others/Boundary.vue
+++ b/components/others/Boundary.vue
@@ -1,6 +1,7 @@
 <template>
   <div v-if="paths.length">
     <bm-polygon
+      isBoundary
       v-for="(path, index) of paths"
       :key="index"
       :path="path"
@@ -48,11 +49,11 @@ export default {
   },
   methods: {
     load () {
-      const {BMap, name} = this
+      const { BMap, name } = this
       const bd = new BMap.Boundary()
       bd.get(name, data => {
         this.paths = data.boundaries.map(boundary => (boundary || []).split(';')
-           .map(point => (([lng, lat]) => ({lng, lat}))(point.split(',').map(p => +p))))
+          .map(point => (([lng, lat]) => ({ lng, lat }))(point.split(',').map(p => +p))))
       })
     }
   }

--- a/components/overlays/Circle.vue
+++ b/components/overlays/Circle.vue
@@ -41,6 +41,10 @@ export default {
     editing: {
       type: Boolean,
       default: false
+    },
+    overLayoutKey: {
+      type: String,
+      default: 'circle'
     }
   },
   watch: {
@@ -144,7 +148,7 @@ export default {
       }, 0)
     },
     load () {
-      const {BMap, map, center, radius, strokeColor, strokeWeight, strokeOpacity, strokeStyle, fillColor, fillOpacity, editing, massClear, clicking, enableEditing, disableEditing, getEditingKey, editingKey} = this
+      const {BMap, map, center, radius, strokeColor, strokeWeight, strokeOpacity, strokeStyle, fillColor, fillOpacity, editing, massClear, clicking, enableEditing, disableEditing, getEditingKey, editingKey, overLayoutKey} = this
       const overlay = new BMap.Circle(createPoint(BMap, {lng: center.lng, lat: center.lat}), radius, {
         strokeColor,
         strokeWeight,
@@ -156,7 +160,7 @@ export default {
         enableMassClear: massClear,
         enableClicking: clicking
       })
-      overlay.__overLayoutKey__ = 'circle'
+      overlay.__overLayoutKey__ = overLayoutKey
       this.originInstance = overlay
       map.addOverlay(overlay)
       bindEvents.call(this, overlay)

--- a/components/overlays/Circle.vue
+++ b/components/overlays/Circle.vue
@@ -156,6 +156,7 @@ export default {
         enableMassClear: massClear,
         enableClicking: clicking
       })
+      overlay.__overLayoutKey__ = 'circle'
       this.originInstance = overlay
       map.addOverlay(overlay)
       bindEvents.call(this, overlay)

--- a/components/overlays/Marker.vue
+++ b/components/overlays/Marker.vue
@@ -146,6 +146,7 @@ export default {
         shadow,
         title
       })
+      overlay.__overLayoutKey__ = 'marker'
       this.originInstance = overlay
       label && overlay && overlay.setLabel(createLabel(BMap, label))
       overlay.setTop(top)

--- a/components/overlays/Overlay.vue
+++ b/components/overlays/Overlay.vue
@@ -1,3 +1,4 @@
+
 <template>
 <div>
   <slot></slot>
@@ -47,6 +48,7 @@ export default {
         }
       }
       const overlay = new CustomOverlay()
+      overlay.__overLayoutKey__ = 'overlay'
       this.originInstance = overlay
       map.addOverlay(overlay)
     }

--- a/components/overlays/Polygon.vue
+++ b/components/overlays/Polygon.vue
@@ -44,9 +44,9 @@ export default {
       type: Boolean,
       default: false
     },
-    isBoundary: {
-      type: Boolean,
-      default: false
+    overLayoutKey: {
+      type: String,
+      default: 'polygon'
     }
   },
   watch: {
@@ -86,7 +86,7 @@ export default {
   },
   methods: {
     load () {
-      const {BMap, map, path, strokeColor, strokeWeight, strokeOpacity, strokeStyle, fillColor, fillOpacity, editing, massClear, clicking} = this
+      const {BMap, map, path, strokeColor, strokeWeight, strokeOpacity, strokeStyle, fillColor, fillOpacity, editing, massClear, clicking, overLayoutKey} = this
       const overlay = new BMap.Polygon(path.map(item => createPoint(BMap, {lng: item.lng, lat: item.lat})), {
         strokeColor,
         strokeWeight,
@@ -98,8 +98,7 @@ export default {
         enableMassClear: massClear,
         enableClicking: clicking
       })
-      // Boundary 范围不需要指定类别
-      if (!this.isBoundary) overlay.__overLayoutKey__ = 'polygon'
+      overlay.__overLayoutKey__ = overLayoutKey
       this.originInstance = overlay
       map.addOverlay(overlay)
       bindEvents.call(this, overlay)

--- a/components/overlays/Polygon.vue
+++ b/components/overlays/Polygon.vue
@@ -43,6 +43,10 @@ export default {
     editing: {
       type: Boolean,
       default: false
+    },
+    isBoundary: {
+      type: Boolean,
+      default: false
     }
   },
   watch: {
@@ -94,6 +98,8 @@ export default {
         enableMassClear: massClear,
         enableClicking: clicking
       })
+      // Boundary 范围不需要指定类别
+      if (!this.isBoundary) overlay.__overLayoutKey__ = 'polygon'
       this.originInstance = overlay
       map.addOverlay(overlay)
       bindEvents.call(this, overlay)

--- a/components/overlays/Polyline.vue
+++ b/components/overlays/Polyline.vue
@@ -34,6 +34,10 @@ export default {
     editing: {
       type: Boolean,
       default: false
+    },
+    overLayoutKey: {
+      type: String,
+      default: 'polyline'
     }
   },
   watch: {
@@ -67,7 +71,7 @@ export default {
   },
   methods: {
     load () {
-      const {BMap, map, path, strokeColor, strokeWeight, strokeOpacity, strokeStyle, editing, massClear, clicking} = this
+      const {BMap, map, path, strokeColor, strokeWeight, strokeOpacity, strokeStyle, editing, massClear, clicking, overLayoutKey} = this
       const overlay = new BMap.Polyline(path.map(item => createPoint(BMap, {lng: item.lng, lat: item.lat})), {
         strokeColor,
         strokeWeight,
@@ -77,6 +81,7 @@ export default {
         enableMassClear: massClear,
         enableClicking: clicking
       })
+      overlay.__overLayoutKey__ = overLayoutKey
       this.originInstance = overlay
       map.addOverlay(overlay)
       bindEvents.call(this, overlay)


### PR DESCRIPTION
1、添加多边形、圆形、线鼠标右键事件，用于应对鼠标绘制点线面覆盖物时右键对覆盖物进行编辑删除等操作。

![image](https://user-images.githubusercontent.com/24687496/98437792-277b6380-2120-11eb-8fa1-26ba718c41c1.png)

2、点线面覆盖物添加 overlay 标识，方便在地图绘制覆盖物的时候，可以快速的通过这个key 获取某一类覆盖物的全部坐标。
![image](https://user-images.githubusercontent.com/24687496/98437736-ae7c0c00-211f-11eb-8690-0598a0afe460.png)
